### PR TITLE
Added default initialization for Toggler.target

### DIFF
--- a/Assets/GUI/Scripts/Toggler.cs
+++ b/Assets/GUI/Scripts/Toggler.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class Toggler : MonoBehaviour
 {
     [SerializeField]
-    private GameObject target;
+    private GameObject target = null;
 
     public void Enable()
     {


### PR DESCRIPTION
This avoids an unnecessary Unity warning